### PR TITLE
[FIX] owkaplanmeier: cast to a float before fitting the Kaplan-Meier curve.

### DIFF
--- a/orangecontrib/survival_analysis/widgets/owkaplanmeier.py
+++ b/orangecontrib/survival_analysis/widgets/owkaplanmeier.py
@@ -35,7 +35,7 @@ class EstimatedFunctionCurve:
         return np.array(x), np.array(y)
 
     def __init__(self, time, events, label=None, color=None):
-        self._kmf = KaplanMeierFitter().fit(time, events)
+        self._kmf = KaplanMeierFitter().fit(time.astype(np.float64), events.astype(np.float64))
 
         self.label: str = label
         self.color: List[int] = color


### PR DESCRIPTION
##### Issue


Error occures when [this line](https://github.com/CamDavidsonPilon/lifelines/blob/deceff91908afe31c19a336083566b81f2cae8d7/lifelines/utils/__init__.py#L951 ) is called. When dealing with meta attributes values of numpy array are of type 'object' instead of float (see images below).
```
In [26]: test = np.asarray([1]).squeeze()
In [27]: pd.to_numeric(test)
Out[27]: array(1)
In [28]: test = test.astype(object)
In [29]: pd.to_numeric(test)
---------------------------------------------------------------------------
ValueError                                Traceback (most recent call last)
<ipython-input-29-04b5b66c3566> in <module>
----> 1 pd.to_numeric(test)
~/.pyenv/versions/3.8.6/envs/orange/lib/python3.8/site-packages/pandas/core/tools/numeric.py in to_numeric(arg, errors, downcast)
    147         coerce_numeric = errors not in ("ignore", "raise")
    148         try:
--> 149             values = lib.maybe_convert_numeric(
    150                 values, set(), coerce_numeric=coerce_numeric
    151             )
pandas/_libs/lib.pyx in pandas._libs.lib.maybe_convert_numeric()
ValueError: Buffer has wrong number of dimensions (expected 1, got 0)

```
1.)
<img width="1435" alt="Screenshot 2021-01-12 at 09 04 03" src="https://user-images.githubusercontent.com/15876321/104289318-44823900-54b9-11eb-98f7-37d345342272.png">

2.)
<img width="1432" alt="Screenshot 2021-01-12 at 09 04 39" src="https://user-images.githubusercontent.com/15876321/104289327-4815c000-54b9-11eb-8e62-9453e6333ee5.png">



##### Description of changes


##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
