### PR TITLE
[ENH] owkaplanmeier: change the symbol of censored data

### DIFF
--- a/orangecontrib/survival_analysis/widgets/owkaplanmeier.py
+++ b/orangecontrib/survival_analysis/widgets/owkaplanmeier.py
@@ -5,7 +5,7 @@ from typing import Dict, List, Optional, NamedTuple
 from itertools import zip_longest
 from xml.sax.saxutils import escape
 
-from AnyQt.QtGui import QBrush, QColor
+from AnyQt.QtGui import QBrush, QColor, QPainterPath
 from AnyQt.QtCore import Qt, QSize
 from AnyQt.QtCore import pyqtSignal as Signal
 from pyqtgraph.functions import mkPen
@@ -25,6 +25,13 @@ from Orange.data.filter import IsDefined
 
 MEDIAN_LINE_PEN = pg.mkPen(color=QColor(Qt.darkGray), width=1, style=Qt.DashLine)
 HORIZONTAL_LINE = pg.InfiniteLine(pos=0.5, angle=0, pen=MEDIAN_LINE_PEN)
+
+
+def create_line_symbol():
+    p = QPainterPath()
+    p.moveTo(0, 0)
+    p.lineTo(0, -1)
+    return p
 
 
 class EstimatedFunctionCurve:
@@ -71,7 +78,8 @@ class EstimatedFunctionCurve:
             y=censored_data[:, 1],
             brush=QBrush(Qt.black),
             pen=self.get_pen(width=1, alpha=255),
-            # size=np.full((points.shape[0],), 10.1),
+            symbol=create_line_symbol(),
+            size=15,
         )
         self.censored_data.setZValue(10)
 


### PR DESCRIPTION
##### Issue
The curve feels crowded when there is a lot of censored samples.

<img width="1190" alt="Screenshot 2021-03-10 at 17 08 40" src="https://user-images.githubusercontent.com/15876321/110661263-ad89e280-81c4-11eb-9bdc-5d3ec60bc003.png">

##### Description of changes
Change the symbol for rendering censored samples (draw lines instead of circles).

<img width="1415" alt="Screenshot 2021-03-10 at 17 01 07" src="https://user-images.githubusercontent.com/15876321/110661281-afec3c80-81c4-11eb-8a16-6ec37b8c570e.png">

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
